### PR TITLE
GH-89 fix premature termination of automl response handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ ENV/
 .vscode/
 
 JPEGS/
+*.tgz

--- a/config/BL-831.config
+++ b/config/BL-831.config
@@ -6,7 +6,7 @@ loopdhs:
         host: voltron.bl831.als.lbl.gov
         port: 5000
     axis:
-        host: axis6.bl1231.als.lbl.gov
+        host: axis6.bl831.als.lbl.gov
         port: 80
         camera: 1
     jpeg_receiver:

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -523,6 +523,8 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                 result = ['LOOP_INFO', index, status, tipX, tipY, pinBaseX, fiberWidth, loopWidth, boxMinX, boxMaxX, boxMinY, boxMaxY, loopWidthX, isMicroMount, loopClass, loopScore]
                 msg = ' '.join(map(str,result))
                 ao.state.loop_images.add_results(result)
+                _logger.info(f'SEND OPERATION UPDATE TO DCSS: {msg}')
+                context.get_connection('dcss_conn').send(DcssHtoSOperationUpdate(ao.operation_name, ao.operation_handle, msg))
 
                 # Draw the AutoML bounding box
                 if context.config.save_images:
@@ -536,14 +538,13 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                         draw_bounding_box(file_to_adorn, upper_left, lower_right, tip)
                     else:
                         _logger.warning(f'DID NOT FIND IMAGE: {file_to_adorn}')
-                
-                _logger.info(f'SEND UPDATE TO DCSS: {msg}')
-                context.get_connection('dcss_conn').send(DcssHtoSOperationUpdate(ao.operation_name, ao.operation_handle, msg))
+
             elif not context.state.collect_images:
                 if context.config.save_images:
                     write_results(context.config.jpeg_save_dir, ao.state.loop_images)
                     plot_results(context.config.jpeg_save_dir, ao.state.loop_images)
                 context.state.rebox_images = ao.state.loop_images
+                _logger.info('SEND OPERATION COMPLETE TO DCSS')
                 context.get_connection('dcss_conn').send(DcssHtoSOperationCompleted(ao.operation_name, ao.operation_handle,'normal','done'))
 
 

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -536,7 +536,7 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                 _logger.info(f'SEND OPERATION UPDATE TO DCSS: {msg}')
                 context.get_connection('dcss_conn').send(DcssHtoSOperationUpdate(ao.operation_name, ao.operation_handle, msg))
 
-                # Draw the AutoML bounding box
+                # Draw the AutoML bounding box if we are saving files to disk.
                 if context.config.save_images:
                     upper_left = [message.bb_minX,message.bb_minY]
                     lower_right = [message.bb_maxX,message.bb_maxY]
@@ -550,9 +550,8 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                         _logger.warning(f'DID NOT FIND IMAGE: {file_to_adorn}')
 
                 sent = ao.state.image_index
-                _logger.debug(f'=================================================sent: {sent}')
                 received = ao.state.automl_responses_received
-                _logger.debug(f'=================================================received: {received}')
+                _logger.debug(f'SENT: {sent} RECEIVED: {received}' )
             elif ao.state.automl_responses_received == ao.state.image_index:
                 if context.config.save_images:
                     write_results(context.config.jpeg_save_dir, ao.state.loop_images)

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -550,6 +550,7 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                 # Can we check to make sure there are no outstanding AutoML responses?
                 # Maybe compare number sent to number received?
                 sent = ao.state.image_index
+                _logger.debug(f'=================================================sent: {sent}')
                 # increment our received counter
                 ao.state.automl_responses_received += 1
                 received = ao.state.automl_responses_received

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -546,13 +546,13 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                         draw_bounding_box(file_to_adorn, upper_left, lower_right, tip)
                     else:
                         _logger.warning(f'DID NOT FIND IMAGE: {file_to_adorn}')
-            # still not waiting for all AutoML responses!!!
-            # Can we check to make sure there are no outstanding AutoML responses?
-            # Maybe compare number sent to number received?
-            sent = ao.state.image_index
-            # increment our received counter
-            ao.state.automl_responses_received += 1
-            received = ao.state.automl_responses_received
+                # still not waiting for all AutoML responses!!!
+                # Can we check to make sure there are no outstanding AutoML responses?
+                # Maybe compare number sent to number received?
+                sent = ao.state.image_index
+                # increment our received counter
+                ao.state.automl_responses_received += 1
+                received = ao.state.automl_responses_received
             elif not context.state.collect_images and received == sent:
                 if context.config.save_images:
                     write_results(context.config.jpeg_save_dir, ao.state.loop_images)

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -554,7 +554,7 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                         _logger.warning(f'DID NOT FIND IMAGE: {file_to_adorn}')
 
             # unfortunately, I think we can still have received == sent if automl is very fast.
-            elif ao.state.automl_responses_received == ao.state.image_index and not ao.state.collect_images:
+            elif ao.state.automl_responses_received == ao.state.image_index and not context.state.collect_images:
                 sent = ao.state.image_index
                 _logger.debug(f'SENT: {sent} RECEIVED: {received}' )
                 if context.config.save_images:

--- a/loopDHS.py
+++ b/loopDHS.py
@@ -528,7 +528,11 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
         elif ao.operation_name == 'collectLoopImages':
             # increment automl responses received
             ao.state.automl_responses_received += 1
+            received = ao.state.automl_responses_received
+
             if ao.state.automl_responses_received < ao.state.image_index:
+                sent = ao.state.image_index
+                _logger.debug(f'SENT: {sent} RECEIVED: {received}' )
                 index = message.image_key.split(':')[2]
                 result = ['LOOP_INFO', index, status, tipX, tipY, pinBaseX, fiberWidth, loopWidth, boxMinX, boxMaxX, boxMinY, boxMaxY, loopWidthX, isMicroMount, loopClass, loopScore]
                 msg = ' '.join(map(str,result))
@@ -549,10 +553,10 @@ def automl_predict_response(message:AutoMLPredictResponse, context:DcssContext):
                     else:
                         _logger.warning(f'DID NOT FIND IMAGE: {file_to_adorn}')
 
+            # unfortunately, I think we can still have received == sent if automl is very fast.
+            elif ao.state.automl_responses_received == ao.state.image_index and not ao.state.collect_images:
                 sent = ao.state.image_index
-                received = ao.state.automl_responses_received
                 _logger.debug(f'SENT: {sent} RECEIVED: {received}' )
-            elif ao.state.automl_responses_received == ao.state.image_index:
                 if context.config.save_images:
                     write_results(context.config.jpeg_save_dir, ao.state.loop_images)
                     plot_results(context.config.jpeg_save_dir, ao.state.loop_images)


### PR DESCRIPTION
I moved the htos_operation_complete message into the automl_predict_response handler, but I'm still missing the last few response messages from AutoML. 

I need some way to assure there are no outstanding AutoML inference requests we are waiting to receive BEFORE sending the  `htos_operation_completed collectLoopImages` message and deleting the activeOp.